### PR TITLE
Fix placement of docstring for lmaterialize

### DIFF
--- a/src/linalg/mul.jl
+++ b/src/linalg/mul.jl
@@ -62,16 +62,20 @@ similar(M::Mul) = similar(M, eltype(M))
 
 materializes arrays iteratively, left-to-right.
 """
+lmaterialize(M::Mul) = _lmaterialize(M.factors...)
 
 _lmaterialize(A, B) = materialize(Mul((A,B)))
 _lmaterialize(A, B, C, D...) = _lmaterialize(materialize(Mul((A,B))), C, D...)
 
-lmaterialize(M::Mul) = _lmaterialize(M.factors...)
+"""
+   rmaterialize(M::Mul)
+
+materializes arrays iteratively, right-to-left.
+"""
+rmaterialize(M::Mul) = _rmaterialize(reverse(M.factors)...)
 
 _rmaterialize(Z, Y) = materialize(Mul((Y,Z)))
 _rmaterialize(Z, Y, X, W...) = _rmaterialize(materialize(Mul((Y,Z))), X, W...)
-
-rmaterialize(M::Mul) = _rmaterialize(reverse(M.factors)...)
 
 
 *(A::Mul, B::Mul) = materialize(Mul(A.factors..., B.factors...))


### PR DESCRIPTION
On Julia 0.7, `using LazyArrays` prints a warning:
```julia
julia> using LazyArrays
[ Info: Precompiling LazyArrays [5078a376-72f3-5289-bfd5-ec5146d43c02]
┌ Warning: Deprecated syntax `multiple line breaks between doc string and object` at /home/sebastian/.julia/packages/LazyArrays/tYXaD/src/linalg/mul.jl:66.
│ Use `at most one line break` instead.
└ @ ~/.julia/packages/LazyArrays/tYXaD/src/linalg/mul.jl:66
```
The warning is due to the docstring of `lmaterialize` that is not attached to any function.

This PR moves `lmaterialize` to its docstring and adds an equivalent docstring for `rmaterialize`.